### PR TITLE
Add field accessors

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ changelog:
 # Homebrew
 brews:
   -
-    github:
+    tap:
       owner: sampointer
       name: homebrew-digaws
 

--- a/ranges/prefixes.go
+++ b/ranges/prefixes.go
@@ -7,6 +7,7 @@ import (
 
 // Prefix is an interface that both IPv4 and IPv6 structs implement
 type Prefix interface {
+	GetRegion() string
 	JSON() (string, error)
 	String() string
 }
@@ -39,6 +40,12 @@ func (p PrefixIPv4) JSON() (string, error) {
 	return string(out), nil
 }
 
+//GetRegion is an accessor method for the Region field, present in order that
+//the Prefix interface can expose it.
+func (p PrefixIPv4) GetRegion() string {
+	return p.Region
+}
+
 // PrefixIPv6 holds the detail of a given AWS IPv6 prefix
 type PrefixIPv6 struct {
 	IPPrefix           string `json:"ipv6_prefix"`
@@ -65,4 +72,10 @@ func (p PrefixIPv6) JSON() (string, error) {
 		return "", err
 	}
 	return string(out), nil
+}
+
+//GetRegion is an accessor method for the Region field, present in order that
+//the Prefix interface can expose it.
+func (p PrefixIPv6) GetRegion() string {
+	return p.Region
 }

--- a/ranges/prefixes_test.go
+++ b/ranges/prefixes_test.go
@@ -65,3 +65,16 @@ func TestPrefixJSON(t *testing.T) {
 		)
 	})
 }
+
+func TestPrefixGetRegion(t *testing.T) {
+	t.Parallel()
+	t.Run("IPv4", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, prefixIPv4.GetRegion(), prefixIPv4.Region)
+	})
+
+	t.Run("IPv6", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, prefixIPv6.GetRegion(), prefixIPv6.Region)
+	})
+}


### PR DESCRIPTION
Add `prefix.GetRegion()` accessor method to allow the region to be accessed via the `Prefix` interface.